### PR TITLE
openSSL Certificate Revocation List (CRL) implementation

### DIFF
--- a/src/include/microhttpd.h
+++ b/src/include/microhttpd.h
@@ -1105,6 +1105,32 @@ enum MHD_TLS_CipherAlgorithm
 };
 
 /**
+ * @brief TLS client certificate mode.
+ */
+enum MHD_TLS_ClientCertificateMode
+{
+  /**
+   * @brief Don't request a client certificate. This is the default.
+   */
+  MHD_TLS_CLIENT_CERTIFICATE_MODE_DISABLE = 0,
+
+  /**
+   * @brief Request a client certificate but don't require it.
+   */
+  MHD_TLS_CLIENT_CERTIFICATE_MODE_REQUEST = 1,
+
+  /**
+   * @brief Require a client certificate.
+   */
+  MHD_TLS_CLIENT_CERTIFICATE_MODE_REQUIRE = 2,
+
+  /**
+   * @brief Upper-bound value.
+   */
+  MHD_TLS_CLIENT_CERTIFICATE_MODE_MAX = MHD_TLS_CLIENT_CERTIFICATE_MODE_REQUIRE
+};
+
+/**
  * @brief Flags for the `struct MHD_Daemon`.
  *
  * Note that MHD will run automatically in background thread(s) only
@@ -1782,7 +1808,17 @@ enum MHD_OPTION
    * For GnuTLS: not implemented yet!
    *
    */
-    MHD_OPTION_TLS_MEM_CRL = 33
+    MHD_OPTION_TLS_MEM_CRL = 33,
+
+  /**
+   * Set the client certificate mode to use for HTTPS connections with client
+   * authentication via certificates. See #MHD_TLS_ClientCertificateMode for
+   * allowed values. This makes only sense if #MHD_OPTION_HTTPS_MEM_TRUST has
+   * been set also.
+   * Default is #MHD_TLS_CLIENT_CERTIFICATE_MODE_REQUIRE if #MHD_OPTION_HTTPS_MEM_TRUST
+   * has been set, otherwise MHD_TLS_CLIENT_CERTIFICATE_MODE_DISABLE.
+   */
+    MHD_OPTION_TLS_CLIENT_CERTIFICATE_MODE = 34
 };
 
 /**

--- a/src/include/microhttpd.h
+++ b/src/include/microhttpd.h
@@ -1772,7 +1772,17 @@ enum MHD_OPTION
    * SSL_CTX_set_cert_cb(). It will receive the OpenSSL SSL session as its
    * first parameter. The second parameter will always be @c NULL.
    */
-    MHD_OPTION_TLS_CERT_CALLBACK = 32
+    MHD_OPTION_TLS_CERT_CALLBACK = 32,
+
+  /**
+   * Memory pointer to a `const char *` specifying the CRL (certificate
+   * revocation list) in PEM format for client authentication via certificates.
+   * This makes only sense if #MHD_OPTION_HTTPS_MEM_TRUST has been set also.
+   *
+   * For GnuTLS: not implemented yet!
+   *
+   */
+    MHD_OPTION_TLS_MEM_CRL = 33
 };
 
 /**

--- a/src/microhttpd/internal.h
+++ b/src/microhttpd/internal.h
@@ -1642,6 +1642,11 @@ struct MHD_Daemon
    */
   const char *https_mem_trust;
 
+  /**
+   * Pointer to our SSL/TLS certificate revocation list (in ASCII) in memory.
+   */
+  const char *https_mem_crl;
+
 #endif /* HTTPS_SUPPORT */
 
 #ifdef DAUTH_SUPPORT

--- a/src/microhttpd/internal.h
+++ b/src/microhttpd/internal.h
@@ -1612,6 +1612,11 @@ struct MHD_Daemon
   enum MHD_TLS_EngineType tls_engine_type;
 
   /**
+   * @brief TLS client certificate mode to use.
+   */
+  enum MHD_TLS_ClientCertificateMode tls_client_certificate_mode;
+
+  /**
    * TLS context.
    */
   struct MHD_TLS_Context *tls_context;

--- a/src/microhttpd/tls.c
+++ b/src/microhttpd/tls.c
@@ -297,6 +297,24 @@ MHD_TLS_set_context_client_certificate_mode (struct MHD_TLS_Context *context,
 }
 
 bool
+MHD_TLS_set_context_certificate_revocation_list (struct MHD_TLS_Context *context,
+                                                 const char *crl)
+{
+  if (NULL == context)
+    return false;
+
+  if (NULL == crl)
+    {
+      MHD_TLS_LOG_CONTEXT (context,
+                           _("Invalid certificate revocation list\n"));
+      return false;
+    }
+
+  return context->engine->set_context_certificate_revocation_list(context,
+                                                                  crl);
+}
+
+bool
 MHD_TLS_set_context_cipher_priorities (struct MHD_TLS_Context *context,
                                        const char *priorities)
 {

--- a/src/microhttpd/tls.h
+++ b/src/microhttpd/tls.h
@@ -82,32 +82,6 @@ typedef ssize_t
                           size_t size);
 
 /**
- * @brief Client certificate mode.
- */
-enum MHD_TLS_ClientCertificateMode
-{
-  /**
-   * @brief Don't request a client certificate. This is the default.
-   */
-  MHD_TLS_CLIENT_CERTIFICATE_MODE_DISABLE = 0,
-
-  /**
-   * @brief Request a client certificate but don't require it.
-   */
-  MHD_TLS_CLIENT_CERTIFICATE_MODE_REQUEST = 1,
-
-  /**
-   * @brief Require a client certificate.
-   */
-  MHD_TLS_CLIENT_CERTIFICATE_MODE_REQUIRE = 2,
-
-  /**
-   * @brief Upper-bound value.
-   */
-  MHD_TLS_CLIENT_CERTIFICATE_MODE_MAX = MHD_TLS_CLIENT_CERTIFICATE_MODE_REQUIRE
-};
-
-/**
  * @name Special return values for session read/write functions.
  * @{
  */

--- a/src/microhttpd/tls.h
+++ b/src/microhttpd/tls.h
@@ -276,6 +276,19 @@ struct MHD_TLS_Engine
                                                enum MHD_TLS_ClientCertificateMode mode);
 
   /**
+   * @brief Set certificate revocation list for client certificate verification.
+   *
+   * @param context TLS context.
+   * @param crl Certificate revocation list in PEM format.
+   *
+   * @return @c true on success, @c false otherwise.
+   *
+   * @see #MHD_TLS_set_context_certificate_revocation_list
+   */
+  bool (*set_context_certificate_revocation_list) (struct MHD_TLS_Context *context,
+                                                   const char *crl);
+
+  /**
    * @brief Set the priorities to use on encyption, key exchange and MAC
    * algorithms.
    *
@@ -755,6 +768,22 @@ MHD_TLS_set_context_trust_certificate (struct MHD_TLS_Context *context,
 bool
 MHD_TLS_set_context_client_certificate_mode (struct MHD_TLS_Context *context,
                                              enum MHD_TLS_ClientCertificateMode mode);
+
+/**
+ * @brief Set the client certificate revocation list for client certificate verification.
+ *
+ * By default, client certificates are not checked for revocation. But you can provide
+ * a certificate revocation list (CRL) to explicitly make client certificate verification
+ * fail for specific certificates (revoke certificates).
+ *
+ * @param context TLS context.
+ * @param crl Certificate revocation list in PEM format.
+ *
+ * @return @c true on success, @c false otherwise.
+ */
+bool
+MHD_TLS_set_context_certificate_revocation_list (struct MHD_TLS_Context *context,
+                                                 const char *crl);
 
 /**
  * @brief Set the priorities to use on encyption, key exchange and MAC

--- a/src/microhttpd/tls_gnutls.c
+++ b/src/microhttpd/tls_gnutls.c
@@ -334,6 +334,16 @@ MHD_TLS_gnutls_set_context_client_certificate_mode (struct MHD_TLS_Context *cont
 }
 
 static bool
+MHD_TLS_gnutls_set_context_certificate_revocation_list (struct MHD_TLS_Context *context,
+                                                        const char *crl)
+{
+  MHD_TLS_LOG_CONTEXT (context,
+                       _("Setting CRL for GnuTLS not implemented yet\n"));
+
+  return false;
+}
+
+static bool
 MHD_TLS_gnutls_set_context_cipher_priorities (struct MHD_TLS_Context *context,
                                               const char *priorities)
 {
@@ -635,6 +645,7 @@ const struct MHD_TLS_Engine tls_engine_gnutls =
   MHD_TLS_gnutls_set_context_certificate,
   MHD_TLS_gnutls_set_context_trust_certificate,
   MHD_TLS_gnutls_set_context_client_certificate_mode,
+  MHD_TLS_gnutls_set_context_certificate_revocation_list,
   MHD_TLS_gnutls_set_context_cipher_priorities,
   MHD_TLS_gnutls_init_session,
   MHD_TLS_gnutls_deinit_session,


### PR DESCRIPTION
Hi Gaulthier,

here is my announced pull-request :-)

openSSL Certificate Revocation List (CRL) implementation incl. new option  MHD_OPTION_TLS_CLIENT_CERTIFICATE_MODE

Greets
Roman